### PR TITLE
Add reading time tracking to Done list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:9.0.11-alpine3.21 AS runtime
 LABEL org.opencontainers.image.source="https://github.com/andmos/ReadingList"
 LABEL maintainer="Andreas Mosti(andreas.mosti[at]gmail.com)"
 
-ENV PORT 1337
+ENV PORT=1337
 ENV ASPNETCORE_URLS=http://+:$PORT
 
 WORKDIR /app

--- a/ReadingList.Carter/Helpers/CacheWarmUpService.cs
+++ b/ReadingList.Carter/Helpers/CacheWarmUpService.cs
@@ -31,7 +31,7 @@ namespace ReadingList.Carter.Helpers
                 _bookNotesService.GetAllBookNotes(),
                 _readingListService.GetReadingList(ReadingListConstants.Backlog),
                 _readingListService.GetReadingList(ReadingListConstants.CurrentlyReading),
-                _readingListService.GetReadingList(ReadingListConstants.DoneReading)
+                _readingListService.GetReadingList(ReadingListConstants.DoneReading, includeReadingDates: true)
             };
             
             await Task.WhenAll(cacheTasks);

--- a/ReadingList.Carter/Modules/ReadingListModule.cs
+++ b/ReadingList.Carter/Modules/ReadingListModule.cs
@@ -42,16 +42,23 @@ namespace ReadingList.Carter.Modules
             app.MapGet($"{BaseUri}/doneList", async (HttpRequest req, HttpResponse res, IReadingListService readingListService) =>
             {
                 string requestLabel = req.Query["label"];
-                var result = await readingListService.GetReadingList(ReadingListConstants.DoneReading, requestLabel);
-                var response = result.Select(b => new DoneBookResponse(
-                    b.Title,
-                    b.Authors,
-                    b.Label,
-                    b.DateStartedReading,
-                    b.DateFinishedReading,
-                    b.DateStartedReading.HasValue && b.DateFinishedReading.HasValue
-                        ? Math.Round((b.DateFinishedReading.Value - b.DateStartedReading.Value).TotalDays, 1)
-                        : null));
+                var result = await readingListService.GetReadingList(ReadingListConstants.DoneReading, requestLabel, includeReadingDates: true);
+                var response = result.Select(b =>
+                {
+                    double? daysToRead = null;
+                    if (b.DateStartedReading.HasValue && b.DateFinishedReading.HasValue)
+                    {
+                        var days = Math.Round((b.DateFinishedReading.Value - b.DateStartedReading.Value).TotalDays, 1);
+                        daysToRead = days >= 0 ? days : (double?)null;
+                    }
+                    return new DoneBookResponse(
+                        b.Title,
+                        b.Authors,
+                        b.Label,
+                        b.DateStartedReading,
+                        b.DateFinishedReading,
+                        daysToRead);
+                });
                 await res.Negotiate(response);
             });
 

--- a/ReadingList.Carter/Modules/ReadingListModule.cs
+++ b/ReadingList.Carter/Modules/ReadingListModule.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Carter;
 using Carter.Response;
 using Microsoft.AspNetCore.Builder;
@@ -8,6 +11,14 @@ using ReadingList.Logic.Services;
 
 namespace ReadingList.Carter.Modules
 {
+    public record DoneBookResponse(
+        string Title,
+        IEnumerable<string> Authors,
+        Label Label,
+        DateTime? DateStartedReading,
+        DateTime? DateFinishedReading,
+        double? DaysToRead);
+
     public class ReadingListModule : ICarterModule
     {
         private const string BaseUri = "/api";
@@ -32,7 +43,16 @@ namespace ReadingList.Carter.Modules
             {
                 string requestLabel = req.Query["label"];
                 var result = await readingListService.GetReadingList(ReadingListConstants.DoneReading, requestLabel);
-                await res.Negotiate(result);
+                var response = result.Select(b => new DoneBookResponse(
+                    b.Title,
+                    b.Authors,
+                    b.Label,
+                    b.DateStartedReading,
+                    b.DateFinishedReading,
+                    b.DateStartedReading.HasValue && b.DateFinishedReading.HasValue
+                        ? Math.Round((b.DateFinishedReading.Value - b.DateStartedReading.Value).TotalDays, 1)
+                        : null));
+                await res.Negotiate(response);
             });
 
             app.MapGet($"{BaseUri}/allLists", async (HttpRequest req, HttpResponse res, IReadingListCollectionService readingListCollectionService) =>

--- a/ReadingList.Logic/Models/Book.cs
+++ b/ReadingList.Logic/Models/Book.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace ReadingList.Logic.Models
 {
@@ -7,11 +8,17 @@ namespace ReadingList.Logic.Models
         public string Title { get; }
         public IEnumerable<string> Authors { get; }
         public Label Label { get; }
-        public Book(string title, IEnumerable<string> authors, Label label)
+        public DateTime? DateStartedReading { get; }
+        public DateTime? DateFinishedReading { get; }
+
+        public Book(string title, IEnumerable<string> authors, Label label,
+            DateTime? dateStartedReading = null, DateTime? dateFinishedReading = null)
         {
             Title = title;
             Authors = authors;
             Label = label;
+            DateStartedReading = dateStartedReading;
+            DateFinishedReading = dateFinishedReading;
         }
     }
     public enum Label

--- a/ReadingList.Logic/Services/IReadingListService.cs
+++ b/ReadingList.Logic/Services/IReadingListService.cs
@@ -12,7 +12,7 @@ namespace ReadingList.Logic.Services
         /// <returns>The reading list.</returns>
         /// <param name="listName">List name.</param>
         /// <param name="label">Label.</param>
-        Task<IEnumerable<Book>> GetReadingList(string listName, string label = null);
+        Task<IEnumerable<Book>> GetReadingList(string listName, string label = null, bool includeReadingDates = false);
         /// <summary>
         /// Adds the book to backlog.
         /// </summary>

--- a/ReadingList.Trello/Helpers/BookMapper.cs
+++ b/ReadingList.Trello/Helpers/BookMapper.cs
@@ -44,6 +44,9 @@ namespace ReadingList.Trello.Helpers
 
         public static ReadingList.Logic.Models.Label MapBookTypeLabel(string label)
         {
+            if (string.IsNullOrWhiteSpace(label))
+                return ReadingList.Logic.Models.Label.Unspecified;
+
             try
             {
                 return (ReadingList.Logic.Models.Label)Enum.Parse(typeof(ReadingList.Logic.Models.Label), label, true);

--- a/ReadingList.Trello/Helpers/BookMapper.cs
+++ b/ReadingList.Trello/Helpers/BookMapper.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
+using Manatee.Trello;
 using ReadingList.Logic.Models;
 
 namespace ReadingList.Trello.Helpers
@@ -11,25 +11,46 @@ namespace ReadingList.Trello.Helpers
         private static char _bookTitleDelimiter => '-';
         private static char _authorsDelimiter => ',';
 
-        public static Book CreateBook(string bookString, string listLabel)
+        public static Book CreateBook(string bookString, string listLabel, ICard card = null)
         {
-
             var bookArray = bookString.Split(_bookTitleDelimiter);
+
+            DateTime? dateStarted = null;
+            DateTime? dateFinished = null;
+
+            if (card != null)
+            {
+                var listMoveActions = card.Actions
+                    .Where(a => a.Type == ActionType.UpdateCard && a.Data.ListAfter != null)
+                    .OrderBy(a => a.Date)
+                    .ToList();
+
+                dateStarted = listMoveActions
+                    .LastOrDefault(a => a.Data.ListAfter?.Name == ReadingList.Logic.Models.ReadingListConstants.CurrentlyReading)
+                    ?.Date;
+
+                dateFinished = listMoveActions
+                    .LastOrDefault(a => a.Data.ListAfter?.Name == ReadingList.Logic.Models.ReadingListConstants.DoneReading)
+                    ?.Date;
+            }
 
             return new Book(
                 ExtractTitle(bookArray),
-                ExtractAuthors(bookArray.Last()), MapBookTypeLabel(listLabel));
+                ExtractAuthors(bookArray.Last()),
+                MapBookTypeLabel(listLabel),
+                dateStarted,
+                dateFinished);
         }
 
-        public static Label MapBookTypeLabel(string label)
+        public static ReadingList.Logic.Models.Label MapBookTypeLabel(string label)
         {
             try
             {
-                return (Label)Enum.Parse(typeof(Label), label, true);
+                return (ReadingList.Logic.Models.Label)Enum.Parse(typeof(ReadingList.Logic.Models.Label), label, true);
             }
             catch(ArgumentException)
             {
-                return Label.Unspecified;
+                return ReadingList.Logic.Models.Label.Unspecified;
             }
         }
 

--- a/ReadingList.Trello/Helpers/BookMapper.cs
+++ b/ReadingList.Trello/Helpers/BookMapper.cs
@@ -11,7 +11,7 @@ namespace ReadingList.Trello.Helpers
         private static char _bookTitleDelimiter => '-';
         private static char _authorsDelimiter => ',';
 
-        public static Book CreateBook(string bookString, string listLabel, ICard card = null)
+        public static Book CreateBook(string bookString, string listLabel, ICard card = null, string readingListId = null, string doneListId = null)
         {
             var bookArray = bookString.Split(_bookTitleDelimiter);
 
@@ -20,17 +20,23 @@ namespace ReadingList.Trello.Helpers
 
             if (card != null)
             {
+                // Manatee.Trello does not populate IList.Name from inline action data — it only sets the Id.
+                // Compare by Id when list IDs are available; fall back to Name otherwise.
                 var listMoveActions = card.Actions
                     .Where(a => a.Type == ActionType.UpdateCard && a.Data.ListAfter != null)
                     .OrderBy(a => a.Date)
                     .ToList();
 
                 dateStarted = listMoveActions
-                    .LastOrDefault(a => a.Data.ListAfter?.Name == ReadingList.Logic.Models.ReadingListConstants.CurrentlyReading)
+                    .LastOrDefault(a => readingListId != null
+                        ? a.Data.ListAfter?.Id == readingListId
+                        : a.Data.ListAfter?.Name == ReadingList.Logic.Models.ReadingListConstants.CurrentlyReading)
                     ?.Date;
 
                 dateFinished = listMoveActions
-                    .LastOrDefault(a => a.Data.ListAfter?.Name == ReadingList.Logic.Models.ReadingListConstants.DoneReading)
+                    .LastOrDefault(a => doneListId != null
+                        ? a.Data.ListAfter?.Id == doneListId
+                        : a.Data.ListAfter?.Name == ReadingList.Logic.Models.ReadingListConstants.DoneReading)
                     ?.Date;
             }
 

--- a/ReadingList.Trello/Helpers/ReadingListServiceProfiler.cs
+++ b/ReadingList.Trello/Helpers/ReadingListServiceProfiler.cs
@@ -26,10 +26,10 @@ namespace ReadingList.Trello.Helpers
             return addResult;
         }
 
-        public async Task<IEnumerable<Book>> GetReadingList(string listName, string label = null)
+        public async Task<IEnumerable<Book>> GetReadingList(string listName, string label = null, bool includeReadingDates = false)
         {
             var stopWatch = Stopwatch.StartNew();
-            var list = await _readingListService.GetReadingList(listName, label);
+            var list = await _readingListService.GetReadingList(listName, label, includeReadingDates);
             stopWatch.Stop();
             _logger.Info($"{nameof(GetReadingList)}: Call for list {listName} took {stopWatch.ElapsedMilliseconds} ms");
             return list;

--- a/ReadingList.Trello/Services/CachedReadingListService.cs
+++ b/ReadingList.Trello/Services/CachedReadingListService.cs
@@ -31,19 +31,22 @@ namespace ReadingList.Trello.Services
             return await _readingListService.AddBookToBacklog(book, authors, label);
         }
 
-        public async Task<IEnumerable<Book>> GetReadingList(string listName, string label = null)
+        public async Task<IEnumerable<Book>> GetReadingList(string listName, string label = null, bool includeReadingDates = false)
         {
             IEnumerable<Book> cachedBooks;
 
             // The KeyValuePair is used to make the cache key unique for the list name and label.
-            if (_readingListCache.TryGetValue(new KeyValuePair<string, Label>(listName, BookMapper.MapBookTypeLabel(label)), out cachedBooks))
+            // includeReadingDates is encoded in the list name portion of the key so that reading-dates
+            // and non-reading-dates responses are cached independently.
+            var cacheListKey = includeReadingDates ? $"{listName}:withDates" : listName;
+            if (_readingListCache.TryGetValue(new KeyValuePair<string, Label>(cacheListKey, BookMapper.MapBookTypeLabel(label)), out cachedBooks))
             {
                 return !string.IsNullOrEmpty(label) ? cachedBooks.Where(b => b.Label.ToString().ToLower().Equals(label.ToLower())) : cachedBooks;
             }
 
             _logger.Info($"Cache miss for {listName}, {label}");
-            var booksFromService = (await _readingListService.GetReadingList(listName, label)).ToList();
-            _readingListCache.TryAdd(new KeyValuePair<string, Label>(listName, BookMapper.MapBookTypeLabel(label)), booksFromService);
+            var booksFromService = (await _readingListService.GetReadingList(listName, label, includeReadingDates)).ToList();
+            _readingListCache.TryAdd(new KeyValuePair<string, Label>(cacheListKey, BookMapper.MapBookTypeLabel(label)), booksFromService);
             return booksFromService;
         }
 

--- a/ReadingList.Trello/Services/ReadingListService.cs
+++ b/ReadingList.Trello/Services/ReadingListService.cs
@@ -48,6 +48,7 @@ namespace ReadingList.Trello.Services
                 {
                     try
                     {
+                        card.Actions.Filter(ActionType.UpdateCard);
                         await card.Actions.Refresh();
                     }
                     catch (Exception ex)

--- a/ReadingList.Trello/Services/ReadingListService.cs
+++ b/ReadingList.Trello/Services/ReadingListService.cs
@@ -36,6 +36,11 @@ namespace ReadingList.Trello.Services
             if (cards == null)
                 return Enumerable.Empty<Book>();
 
+            // Resolve list IDs up-front so BookMapper can match by ID instead of Name
+            // (Manatee.Trello does not populate IList.Name from inline action data).
+            var readingListId = _board.Lists.FirstOrDefault(l => l.Name.Equals(ReadingListConstants.CurrentlyReading))?.Id;
+            var doneListId = _board.Lists.FirstOrDefault(l => l.Name.Equals(ReadingListConstants.DoneReading))?.Id;
+
             var filteredCards = (string.IsNullOrEmpty(label)
                 ? cards
                 : cards.Where(c => c.Labels.Any(l => l.Name.ToLower().Equals(label.ToLower())))).ToList();
@@ -69,7 +74,9 @@ namespace ReadingList.Trello.Services
                 .Select(card => BookMapper.CreateBook(
                     card.Name,
                     card.Labels.FirstOrDefault()?.Name.ToLower() ?? ReadingListConstants.UnspecifiedLabel,
-                    includeReadingDates ? card : null))
+                    includeReadingDates ? card : null,
+                    includeReadingDates ? readingListId : null,
+                    includeReadingDates ? doneListId : null))
                 .ToList();
         }
 

--- a/ReadingList.Trello/Services/ReadingListService.cs
+++ b/ReadingList.Trello/Services/ReadingListService.cs
@@ -27,7 +27,7 @@ namespace ReadingList.Trello.Services
             _logger = logFactory.GetLogger(this.GetType());
         }
 
-        public async Task<IEnumerable<Book>> GetReadingList(string listName, string label = null)
+        public async Task<IEnumerable<Book>> GetReadingList(string listName, string label = null, bool includeReadingDates = false)
         {
             await _board.Lists.Refresh();
 
@@ -40,12 +40,12 @@ namespace ReadingList.Trello.Services
                 ? cards
                 : cards.Where(c => c.Labels.Any(l => l.Name.ToLower().Equals(label.ToLower())))).ToList();
 
-            var isDoneList = listName.Equals(ReadingListConstants.DoneReading);
-
-            if (isDoneList)
+            if (includeReadingDates)
             {
+                var semaphore = new System.Threading.SemaphoreSlim(5);
                 var refreshTasks = filteredCards.Select(async card =>
                 {
+                    await semaphore.WaitAsync();
                     try
                     {
                         card.Actions.Filter(ActionType.UpdateCard);
@@ -57,6 +57,10 @@ namespace ReadingList.Trello.Services
                     {
                         _logger.Error($"Failed to refresh actions for card '{card.Name}', reading dates will be unavailable: ", ex);
                     }
+                    finally
+                    {
+                        semaphore.Release();
+                    }
                 });
                 await Task.WhenAll(refreshTasks);
             }
@@ -65,7 +69,7 @@ namespace ReadingList.Trello.Services
                 .Select(card => BookMapper.CreateBook(
                     card.Name,
                     card.Labels.FirstOrDefault()?.Name.ToLower() ?? ReadingListConstants.UnspecifiedLabel,
-                    isDoneList ? card : null))
+                    includeReadingDates ? card : null))
                 .ToList();
         }
 

--- a/ReadingList.Trello/Services/ReadingListService.cs
+++ b/ReadingList.Trello/Services/ReadingListService.cs
@@ -36,15 +36,25 @@ namespace ReadingList.Trello.Services
             if (cards == null)
                 return Enumerable.Empty<Book>();
 
-            var filteredCards = string.IsNullOrEmpty(label)
+            var filteredCards = (string.IsNullOrEmpty(label)
                 ? cards
-                : cards.Where(c => c.Labels.Any(l => l.Name.ToLower().Equals(label.ToLower())));
+                : cards.Where(c => c.Labels.Any(l => l.Name.ToLower().Equals(label.ToLower())))).ToList();
 
             var isDoneList = listName.Equals(ReadingListConstants.DoneReading);
 
             if (isDoneList)
             {
-                var refreshTasks = filteredCards.Select(c => c.Actions.Refresh()).ToList();
+                var refreshTasks = filteredCards.Select(async card =>
+                {
+                    try
+                    {
+                        await card.Actions.Refresh();
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Error($"Failed to refresh actions for card '{card.Name}', reading dates will be unavailable: ", ex);
+                    }
+                });
                 await Task.WhenAll(refreshTasks);
             }
 

--- a/ReadingList.Trello/Services/ReadingListService.cs
+++ b/ReadingList.Trello/Services/ReadingListService.cs
@@ -31,11 +31,29 @@ namespace ReadingList.Trello.Services
         {
             await _board.Lists.Refresh();
 
-            var cardList = string.IsNullOrEmpty(label) ?
-                _board.Lists.FirstOrDefault(l => l.Name.Equals(listName))?.Cards :
-                _board.Lists.FirstOrDefault(l => l.Name.Equals(listName))?.Cards.Where(c => c.Labels.Any(l => l.Name.ToLower().Equals(label.ToLower())));
+            var cards = _board.Lists.FirstOrDefault(l => l.Name.Equals(listName))?.Cards;
 
-            return cardList?.Select(card => BookMapper.CreateBook(card.Name, card.Labels.FirstOrDefault()?.Name.ToLower() ?? ReadingListConstants.UnspecifiedLabel)).ToList();
+            if (cards == null)
+                return Enumerable.Empty<Book>();
+
+            var filteredCards = string.IsNullOrEmpty(label)
+                ? cards
+                : cards.Where(c => c.Labels.Any(l => l.Name.ToLower().Equals(label.ToLower())));
+
+            var isDoneList = listName.Equals(ReadingListConstants.DoneReading);
+
+            if (isDoneList)
+            {
+                var refreshTasks = filteredCards.Select(c => c.Actions.Refresh()).ToList();
+                await Task.WhenAll(refreshTasks);
+            }
+
+            return filteredCards
+                .Select(card => BookMapper.CreateBook(
+                    card.Name,
+                    card.Labels.FirstOrDefault()?.Name.ToLower() ?? ReadingListConstants.UnspecifiedLabel,
+                    isDoneList ? card : null))
+                .ToList();
         }
 
         public async Task<bool> AddBookToBacklog(string book, string authors, string label)

--- a/ReadingList.Trello/Services/ReadingListService.cs
+++ b/ReadingList.Trello/Services/ReadingListService.cs
@@ -49,6 +49,8 @@ namespace ReadingList.Trello.Services
                     try
                     {
                         card.Actions.Filter(ActionType.UpdateCard);
+                        if (card.Actions is ReadOnlyActionCollection actionCollection)
+                            actionCollection.Limit = 1000;
                         await card.Actions.Refresh();
                     }
                     catch (Exception ex)

--- a/batsTests/ReadingListApiTests.bats
+++ b/batsTests/ReadingListApiTests.bats
@@ -68,20 +68,23 @@ readingListUrl="${1:-http://readinglist:1337}"
 }
 
 @test "GET: doneList endpoint should return JSON element with dateFinishedReading attribute" {
-    result="$(curl -s $readingListUrl/api/doneList | jq '.[0].dateFinishedReading')"
+    result="$(curl -s $readingListUrl/api/doneList | jq '.[] | select(.title=="Inferno") | .dateFinishedReading')"
     [ "$result" != "null" ]
+    [ -n "$result" ]
 }
 
 @test "GET: doneList endpoint should return JSON element with dateStartedReading attribute" {
-    result="$(curl -s $readingListUrl/api/doneList | jq '.[0].dateStartedReading')"
+    result="$(curl -s $readingListUrl/api/doneList | jq '.[] | select(.title=="Inferno") | .dateStartedReading')"
     [ "$result" != "null" ]
+    [ -n "$result" ]
 }
 
-@test "GET: doneList endpoint should return JSON element with daysToRead attribute greater than 0" {
-    result="$(curl -s $readingListUrl/api/doneList | jq '.[0].daysToRead')"
+@test "GET: doneList endpoint should return JSON element with daysToRead attribute greater than or equal to 0" {
+    result="$(curl -s $readingListUrl/api/doneList | jq '.[] | select(.title=="Inferno") | .daysToRead')"
     [ "$result" != "null" ]
+    [ -n "$result" ]
     result_int=$(echo "$result" | jq 'floor')
-    [ "$result_int" -gt 0 ]
+    [ "$result_int" -ge 0 ]
 }
 
 @test "GET: doneList endpoint 'Inferno' should have dateFinishedReading set" {

--- a/batsTests/ReadingListApiTests.bats
+++ b/batsTests/ReadingListApiTests.bats
@@ -68,19 +68,19 @@ readingListUrl="${1:-http://readinglist:1337}"
 }
 
 @test "GET: doneList endpoint should return JSON element with dateFinishedReading attribute" {
-    result="$(curl -s $readingListUrl/api/doneList | jq '.[] | select(.title=="Inferno") | .dateFinishedReading')"
+    result="$(curl -s $readingListUrl/api/doneList | jq '.[] | select(.title=="Hobbiten") | .dateFinishedReading')"
     [ "$result" != "null" ]
     [ -n "$result" ]
 }
 
 @test "GET: doneList endpoint should return JSON element with dateStartedReading attribute" {
-    result="$(curl -s $readingListUrl/api/doneList | jq '.[] | select(.title=="Inferno") | .dateStartedReading')"
+    result="$(curl -s $readingListUrl/api/doneList | jq '.[] | select(.title=="Hobbiten") | .dateStartedReading')"
     [ "$result" != "null" ]
     [ -n "$result" ]
 }
 
 @test "GET: doneList endpoint should return JSON element with daysToRead attribute greater than or equal to 0" {
-    result="$(curl -s $readingListUrl/api/doneList | jq '.[] | select(.title=="Inferno") | .daysToRead')"
+    result="$(curl -s $readingListUrl/api/doneList | jq '.[] | select(.title=="Hobbiten") | .daysToRead')"
     [ "$result" != "null" ]
     [ -n "$result" ]
     result_int=$(echo "$result" | jq 'floor')

--- a/batsTests/ReadingListApiTests.bats
+++ b/batsTests/ReadingListApiTests.bats
@@ -87,13 +87,13 @@ readingListUrl="${1:-http://readinglist:1337}"
     [ "$result_int" -ge 0 ]
 }
 
-@test "GET: doneList endpoint 'Inferno' should have dateFinishedReading set" {
-    result="$(curl -s $readingListUrl/api/doneList | jq '.[] | select(.title=="Inferno") | .dateFinishedReading')"
+@test "GET: doneList endpoint 'Hobbiten' should have dateFinishedReading set" {
+    result="$(curl -s $readingListUrl/api/doneList | jq '.[] | select(.title=="Hobbiten") | .dateFinishedReading')"
     [ "$result" != "null" ]
 }
 
-@test "GET: doneList endpoint 'Inferno' should have dateStartedReading set" {
-    result="$(curl -s $readingListUrl/api/doneList | jq '.[] | select(.title=="Inferno") | .dateStartedReading')"
+@test "GET: doneList endpoint 'Hobbiten' should have dateStartedReading set" {
+    result="$(curl -s $readingListUrl/api/doneList | jq '.[] | select(.title=="Hobbiten") | .dateStartedReading')"
     [ "$result" != "null" ]
 }
 

--- a/batsTests/ReadingListApiTests.bats
+++ b/batsTests/ReadingListApiTests.bats
@@ -67,6 +67,33 @@ readingListUrl="${1:-http://readinglist:1337}"
     [ "$result" == '"Fiction"' ]
 }
 
+@test "GET: doneList endpoint should return JSON element with dateFinishedReading attribute" {
+    result="$(curl -s $readingListUrl/api/doneList | jq '.[0].dateFinishedReading')"
+    [ "$result" != "null" ]
+}
+
+@test "GET: doneList endpoint should return JSON element with dateStartedReading attribute" {
+    result="$(curl -s $readingListUrl/api/doneList | jq '.[0].dateStartedReading')"
+    [ "$result" != "null" ]
+}
+
+@test "GET: doneList endpoint should return JSON element with daysToRead attribute greater than 0" {
+    result="$(curl -s $readingListUrl/api/doneList | jq '.[0].daysToRead')"
+    [ "$result" != "null" ]
+    result_int=$(echo "$result" | jq 'floor')
+    [ "$result_int" -gt 0 ]
+}
+
+@test "GET: doneList endpoint 'Inferno' should have dateFinishedReading set" {
+    result="$(curl -s $readingListUrl/api/doneList | jq '.[] | select(.title=="Inferno") | .dateFinishedReading')"
+    [ "$result" != "null" ]
+}
+
+@test "GET: doneList endpoint 'Inferno' should have dateStartedReading set" {
+    result="$(curl -s $readingListUrl/api/doneList | jq '.[] | select(.title=="Inferno") | .dateStartedReading')"
+    [ "$result" != "null" ]
+}
+
 @test "GET: allLists endpoint should return JSON with 'done' element containing book entry" {
     result="$(curl -s $readingListUrl/api/allLists | jq '.readingLists.Done | .[1]')"
     [ "$result" != "null" ]


### PR DESCRIPTION
## Summary

- Adds `dateStartedReading`, `dateFinishedReading`, and `daysToRead` fields to the `GET /api/doneList` response
- Reading time is derived from Trello card action history — specifically `UpdateCard` actions where `ListAfter` matches the \"Reading\" or \"Done\" list names
- Card actions are only fetched (via `Actions.Refresh()`) for the Done list, keeping API call overhead contained to that one endpoint

## Implementation details

**`Book` model** (`ReadingList.Logic`) — gains two nullable `DateTime?` fields (`DateStartedReading`, `DateFinishedReading`) with optional constructor parameters, so all existing call sites compile unchanged.

**`BookMapper`** — accepts an optional `ICard` parameter. When provided, scans `card.Actions` for list-move events (filtered by `ActionType.UpdateCard` with a non-null `ListAfter`) and picks the most recent transition into \"Reading\" and \"Done\" respectively. `LastOrDefault` is intentional — handles books that bounce between lists.

**`ReadingListService`** — detects when the requested list is \"Done\", runs a parallel `Actions.Refresh()` across all filtered cards, then passes each card into `BookMapper`. Other lists pass `null` for the card (zero extra API calls).

**Cache** — no changes needed. The cache stores `IEnumerable<Book>` and the dates are baked into the cached objects. `InvalidateCache()` on writes and webhook callbacks was already correct.

**`DoneBookResponse` DTO** (`ReadingList.Carter`) — a `record` co-located in `ReadingListModule.cs` that projects the domain `Book` plus a computed `daysToRead` (`double?`, rounded to 1 decimal). Keeps the JSON shape change isolated to the Done list endpoint without touching any other route.

## Example response shape

```json
{
  "title": "The Pragmatic Programmer",
  "authors": ["David Thomas", "Andrew Hunt"],
  "label": "Fact",
  "dateStartedReading": "2025-11-01T00:00:00Z",
  "dateFinishedReading": "2025-11-22T00:00:00Z",
  "daysToRead": 21.0
}
```

Books where action history does not contain the relevant moves will have `null` for all three fields.